### PR TITLE
Upload design assets to storage for Printful orders

### DIFF
--- a/app/api/design/save/route.ts
+++ b/app/api/design/save/route.ts
@@ -28,11 +28,18 @@ export async function POST(request: NextRequest) {
     )
     
     // Guardar el diseño en la base de datos
+    const designDataToStore = {
+      ...designData,
+      printFileUrl: designData.printFileUrl ?? null,
+      printFilePath: designData.printFilePath ?? null,
+      printUploadedAt: designData.printUploadedAt ?? new Date().toISOString()
+    }
+
     const { data, error } = await supabase
       .from('qr_designs')
       .upsert({
         qr_code: code,
-        design_data: designData,
+        design_data: designDataToStore,
         product_size: designData.productOptions?.size || null,
         product_color: designData.productOptions?.color || null,
         product_gender: designData.productOptions?.gender || null,


### PR DESCRIPTION
## Summary
- upload design PNGs from the T-shirt editor to the design/upload API and include the resulting public URL in the saved metadata
- persist hosted asset information with each QR design and surface it when copying or saving designs
- ensure Printful orders fail fast if any design is missing a hosted file and otherwise send the hosted URL to Printful

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc51f2b1bc8329854080b082748300